### PR TITLE
Updating versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ serde_json = "1.0"
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 secp256k1 = {version = "0.16", features = ["recovery"] }
 rlp = "0.4"
-ethereum-types = "0.8"
+ethereum-types = "0.6"
 num-traits = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-tx-sign"
-version = "3.0.0"
+version = "3.0.1"
 description = "Allows you to model a raw ethereum transaction and sign it with your private key"
 repository = "https://github.com/synlestidae/ethereum-tx-sign"
 license = "MIT"
@@ -12,8 +12,8 @@ readme = "README.md"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-tiny-keccak="1.4.2"
-secp256k1 = "0.12"
-rlp = "0.4.2"
-ethereum-types = "0.6.0"
-num-traits = "0.2.10"
+tiny-keccak = { version = "2.0", features = ["keccak"] }
+secp256k1 = {version = "0.16", features = ["recovery"] }
+rlp = "0.4"
+ethereum-types = "0.8"
+num-traits = "0.2"

--- a/src/raw_transaction.rs
+++ b/src/raw_transaction.rs
@@ -1,10 +1,19 @@
-use ethereum_types::{H160, H256, U256};
-use rlp::RlpStream;
+use ethereum_types::{
+    H160,
+    H256,
+    U256
+};
 use num_traits::int;
-use secp256k1::key::SecretKey;
-use secp256k1::Message;
-use secp256k1::Secp256k1;
-use tiny_keccak::keccak256;
+use rlp::RlpStream;
+use secp256k1::{
+    key::SecretKey,
+    Message,
+    Secp256k1,
+};
+use tiny_keccak::{
+    Keccak,
+    Hasher,
+};
 
 /// Description of a Transaction, pending or in the chain.
 #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
@@ -26,7 +35,7 @@ pub struct RawTransaction {
 
 impl RawTransaction {
 
-        /// Signs and returns the RLP-encoded transaction
+    /// Signs and returns the RLP-encoded transaction
     pub fn sign<T: int::PrimInt>(&self, private_key: &H256, chain_id: &T) -> Vec<u8> {
         let chain_id_u64: u64 = chain_id.to_u64().unwrap();
         let hash = self.hash(chain_id_u64);
@@ -75,7 +84,11 @@ impl RawTransaction {
 }
 
 fn keccak256_hash(bytes: &[u8]) -> Vec<u8> {
-    keccak256(bytes).iter().cloned().collect()
+    let mut hasher = Keccak::v256();
+    hasher.update(bytes);
+    let mut resp: [u8; 32] = Default::default();
+    hasher.finalize(&mut resp);
+    resp.iter().cloned().collect()
 }
 
 fn ecdsa_sign(hash: &[u8], private_key: &[u8], chain_id: &u64) -> EcdsaSig {


### PR DESCRIPTION
Updating the version of `secp256k1` supposes to fix a problem on the build when using multiple versions of this crate, it compiles C++ code, so if we have more than one it breaks the linker.