### PR TITLE
Update ethereum-types: 0.8 -> 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ serde_json = "1.0"
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 secp256k1 = {version = "0.17", features = ["recovery"] }
 rlp = "0.4"
-ethereum-types = "0.8"
+ethereum-types = "0.9"
 num-traits = "0.2"


### PR DESCRIPTION
(there's a plenty of other crates that were also updated recently)