### PR TITLE
Change rlp() to rlp_parts()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 secp256k1 = {version = "0.22.1", features = ["recovery"] }
 rlp = "0.5.1"
 num-traits = "0.2"
+bytes = "^1"
 
 [dev-dependencies]
 ethereum-types= "0.13"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@ extern crate serde_json;
 use rlp::{RlpStream, Encodable};
 use secp256k1::{Message, Secp256k1, SecretKey};
 use tiny_keccak::{Hasher, Keccak};
-use bytes::Bytes;
 
 /// Ethereum transaction
 pub trait Transaction {
@@ -78,18 +77,18 @@ pub struct LegacyTransaction {
 }
 
 impl LegacyTransaction {
-    fn rlp<'a>(&'a self) -> Vec<Bytes> {
+    fn rlp<'a>(&'a self) -> Vec<Box<dyn Encodable>> {
         let to: Vec<u8> = match self.to {
             Some(ref to) => to.iter().cloned().collect(),
             None => vec![],
         };
         vec![
-            self.nonce.rlp_bytes().into(),
-            self.gas_price.rlp_bytes().into(),
-            self.gas.rlp_bytes().into(),
-            to.rlp_bytes().into(),
-            self.value.rlp_bytes().into(),
-            self.data.rlp_bytes().into(),
+            Box::new(self.nonce),
+            Box::new(self.gas_price),
+            Box::new(self.gas),
+            Box::new(to.clone()),
+            Box::new(self.value),
+            Box::new(self.data.clone())
         ]
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,10 @@ pub struct LegacyTransaction {
 }
 
 impl LegacyTransaction {
-    fn rlp<'a>(&'a self) -> Vec<Box<dyn Encodable>> {
+    /// Return the fields of the transaction as a list of RLP-encodable 
+    /// parts. The parts must follow the order that they will be encoded,
+    /// hashed, or signed.
+    fn rlp_parts<'a>(&'a self) -> Vec<Box<dyn Encodable>> {
         let to: Vec<u8> = match self.to {
             Some(ref to) => to.iter().cloned().collect(),
             None => vec![],
@@ -99,7 +102,7 @@ impl Transaction for LegacyTransaction {
     }
 
     fn hash(&self) -> [u8; 32] {
-        let rlp = self.rlp();
+        let rlp = self.rlp_parts();
         let mut rlp_stream = RlpStream::new();
         rlp_stream.begin_unbounded_list();
         for r in rlp.iter() {
@@ -114,7 +117,7 @@ impl Transaction for LegacyTransaction {
 
     fn sign(&self, ecdsa: &EcdsaSig) -> Vec<u8> {
         let mut rlp_stream = RlpStream::new();
-        let rlp = self.rlp();
+        let rlp = self.rlp_parts();
         rlp_stream.begin_unbounded_list();
         for r in rlp.iter() {
             rlp_stream.append(r);


### PR DESCRIPTION
Updates the rlp() method to return the individual components of the transaction, and make it part of the Transaction trait. The intent of this is to make rlp_parts more reusable.