### PR TITLE
[WIP] fix: use sha3 keccak256 lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ readme = "README.md"
 [dependencies]
 serde = "^1.0"
 serde_derive = "^1.0"
-tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 secp256k1 = {version = "0.27.0", features = ["recovery"] }
 rlp = "0.5.2"
 num-traits = "0.2"
 bytes = "^1.4.0"
 hex = "0.4.3"
+sha3 = "0.10.8"
 
 [dev-dependencies]
 ethereum-types= "0.14"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ extern crate hex;
 extern crate num_traits;
 extern crate rlp;
 extern crate secp256k1;
-extern crate tiny_keccak;
+extern crate sha3;
 
 #[cfg(test)]
 extern crate ethereum_types;
@@ -21,7 +21,7 @@ use serde::de::Error as SerdeErr;
 use serde::ser::SerializeSeq;
 use serde::Deserialize;
 use std::convert::TryInto;
-use tiny_keccak::{Hasher, Keccak};
+use sha3::{Keccak256, Digest};
 
 /// Ethereum transaction
 pub trait Transaction {
@@ -555,11 +555,9 @@ impl EcdsaSig {
 }
 
 fn keccak256_hash(bytes: &[u8]) -> [u8; 32] {
-    let mut hasher = Keccak::v256();
+    let mut hasher = Keccak256::new();
     hasher.update(bytes);
-    let mut resp: [u8; 32] = Default::default();
-    hasher.finalize(&mut resp);
-    resp
+    hasher.finalize().into()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Attempts to fix #90 by using `sha3` instead of `tiny_keccak`